### PR TITLE
Remove disable-model-invocation from all skills

### DIFF
--- a/brewcode/skills/agents/SKILL.md
+++ b/brewcode/skills/agents/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:agents
 description: Interactive agent creation and improvement orchestrator. Create or improve Claude Code agents.
-disable-model-invocation: true
 user-invocable: true
 argument-hint: "[create <description>|up <name|path>] | <name|path>"
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Task, AskUserQuestion, Skill]

--- a/brewcode/skills/convention/SKILL.md
+++ b/brewcode/skills/convention/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:convention
 description: Analyzes project to extract etalon classes, patterns, and architecture by layer. Generates convention documents in .claude/convention/ and organizes rules.
-disable-model-invocation: true
 argument-hint: "[full|conventions|rules|paths <p1,p2>]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, AskUserQuestion, Skill
 model: opus

--- a/brewcode/skills/grepai/SKILL.md
+++ b/brewcode/skills/grepai/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:grepai
 description: Manages grepai semantic search (setup, status, start, stop, reindex, optimize, upgrade).
-disable-model-invocation: true
 argument-hint: "[setup|status|start|stop|reindex|optimize|upgrade]"
 allowed-tools: Read, Write, Edit, Bash, Task, AskUserQuestion
 model: sonnet

--- a/brewcode/skills/install/SKILL.md
+++ b/brewcode/skills/install/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:install
 description: Installs brewcode prerequisites (brew, coreutils, jq, grepai).
-disable-model-invocation: true
 user-invocable: true
 argument-hint: "(no args) — interactive installer for brew, coreutils, jq, grepai"
 allowed-tools: Read, Bash, AskUserQuestion

--- a/brewcode/skills/plan/SKILL.md
+++ b/brewcode/skills/plan/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:plan
 description: Creates execution plan (PLAN.md) from SPEC or Plan Mode file.
-disable-model-invocation: true
 user-invocable: true
 argument-hint: "[-n] [task-dir|SPEC.md|plan-file] — -n/--noask: no questions to user"
 allowed-tools: Read, Write, Glob, Grep, Bash, Task, AskUserQuestion

--- a/brewcode/skills/setup/SKILL.md
+++ b/brewcode/skills/setup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:setup
 description: Analyzes project structure and tech stack to generate adapted PLAN.md.template in .claude/tasks/templates/.
-disable-model-invocation: true
 argument-hint: "[universal-template-path]"
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion
 context: fork

--- a/brewcode/skills/skills/SKILL.md
+++ b/brewcode/skills/skills/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:skills
 description: Skill management - list, improve, create skills with activation optimization.
-disable-model-invocation: true
 user-invocable: true
 argument-hint: "[list|up|create] [target] | <skill-path>"
 allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Task, WebSearch, WebFetch, AskUserQuestion]

--- a/brewcode/skills/spec/SKILL.md
+++ b/brewcode/skills/spec/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:spec
 description: Creates task specification through research and user interaction.
-disable-model-invocation: true
 argument-hint: "[-n] <description> | <path-to-requirements> — -n/--noask: no questions to user"
 allowed-tools: Read, Write, Glob, Grep, Bash, Task, AskUserQuestion
 model: opus

--- a/brewcode/skills/start/SKILL.md
+++ b/brewcode/skills/start/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:start
 description: Executes task with infinite context and automatic handoff.
-disable-model-invocation: true
 argument-hint: "[task-path] defaults to ref in .claude/TASK.md (first line = active path)"
 allowed-tools: Read, Write, Edit, Bash, Task, Glob, Grep, Skill, AskUserQuestion
 model: opus

--- a/brewcode/skills/teardown/SKILL.md
+++ b/brewcode/skills/teardown/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewcode:teardown
 description: Removes brewcode project files (templates, configs, logs).
-disable-model-invocation: true
 argument-hint: "[--dry-run]"
 allowed-tools: Bash, Read, AskUserQuestion
 context: fork

--- a/brewdoc/skills/auto-sync/SKILL.md
+++ b/brewdoc/skills/auto-sync/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: brewdoc:auto-sync
 description: Universal documentation sync for skills, agents, markdown. Modes - status, init, global, project, file, folder.
-disable-model-invocation: true
 user-invocable: true
 argument-hint: "[status] | [init <path>] | [global] | [path]"
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, WebFetch, Skill


### PR DESCRIPTION
Allow programmatic invocation of all skills via Skill tool. Interactive skills remain safe — AskUserQuestion still prompts for user input at decision points.